### PR TITLE
Feature/bug126368 Fixes for axis / general / relations quick adds support

### DIFF
--- a/src/shared/services/apiCompatibility.js
+++ b/src/shared/services/apiCompatibility.js
@@ -1,0 +1,100 @@
+// TODO(anybody): Remove V121 after all users switch to TP > 3.9.0. Even better, add mashup versioning.
+
+import $, {when} from 'jquery';
+import {isFunction, flatten, map} from 'underscore';
+
+const appConfigurator = require('tau/configurator');
+
+import busNames from 'services/busNames';
+import {equalIgnoreCase} from 'utils';
+
+const isApiVersionLessOrEqualV121 = !isFunction(appConfigurator.getSliceFactory().create().cellActionsV3);
+
+const isSameEntityTypeV121 = (v, entityType) => equalIgnoreCase($(v).data('type'), entityType.name);
+
+const isSameEntityTypeV122 = (v, entityType) => {
+
+    const $v = $(v);
+
+    return equalIgnoreCase($v.data('type-name'), entityType.name) &&
+        equalIgnoreCase($v.data('type-title'), entityType.title);
+
+};
+
+export const isSameEntityType = !isApiVersionLessOrEqualV121 ?
+    isSameEntityTypeV122 : isSameEntityTypeV121;
+
+const makeEntityType = (type) => ({
+    name: type.name, title: type.title
+});
+
+const getEntityTypeOrTypes = (typeData, selector) => {
+
+    const entityType = selector(typeData);
+
+    return entityType ? [makeEntityType(entityType)] : map(typeData, (type) => makeEntityType(selector(type)));
+
+};
+
+const convertEntityTypes = (types, selector) =>
+    flatten(map(types, (v) => getEntityTypeOrTypes(v, selector)));
+
+export const getSliceDefinition = ({config}) =>
+    (config.options && config.options.slice) ? config.options.slice.config.definition : null;
+
+const getEntityTypesV121 = (initData, bindData) => {
+
+    if (bindData.types) {
+
+        return convertEntityTypes(bindData.types, (v) => v.entityType);
+
+    } else if (initData.addAction) {
+
+        return convertEntityTypes(initData.addAction.data.types, (v) => ({name: v.name}));
+
+    } else {
+
+        const sliceDefinition = getSliceDefinition(initData);
+
+        if (sliceDefinition) {
+
+            return convertEntityTypes(sliceDefinition.cells.types, (v) => ({name: v.type}));
+
+        }
+
+    }
+
+    return [];
+
+};
+
+const getEntityTypesV122 = (initData, bindData) => {
+
+    if (bindData.types) {
+
+        return convertEntityTypes(bindData.types, (v) => v.entityType);
+
+    }
+
+    return [];
+
+};
+
+export const getEntityTypes = !isApiVersionLessOrEqualV121 ?
+    getEntityTypesV122 : getEntityTypesV121;
+
+const getStoredAcid = (configurator) => {
+
+    const applicationStore = configurator.getAppStateStore();
+
+    return when(applicationStore.get({fields: ['acid']}));
+
+};
+
+const getGlobalAcid = () => when({acid: null}).promise();
+
+const needGlobalAcid = (busName) =>
+    busName === busNames.TOP_LEFT_ADD_BUTTON_COMPONENT_BUS_NAME && !isApiVersionLessOrEqualV121;
+
+export const getAcid = (configurator, busName) =>
+    needGlobalAcid(busName) ? getGlobalAcid() : getStoredAcid(configurator);

--- a/src/shared/services/busNames.js
+++ b/src/shared/services/busNames.js
@@ -1,0 +1,15 @@
+export default {
+
+    TOP_LEFT_ADD_BUTTON_COMPONENT_BUS_NAME: 'board plus quick add general',
+
+    VIEWBOARD_AND_ONE_BY_ONE_AND_TIMELINE_BUTTON_INSIDE_CELL_COMPONENT_BUS_NAME: 'board plus quick add cells',
+    VIEWBOARD_AND_TIMELINE_BUTTON_INSIDE_AXES_COMPONENT_BUS_NAME: 'board axis quick add',
+
+    VIEWLIST_BUTTON_COMPONENT_BUS_NAME: 'board.cell.quick.add',
+
+    ENTITY_TABS_QUICK_ADD_BUS_NAME: 'entity quick add',
+
+    RELATIONS_MASTER_TAB_COMPONENT_BUS_NAME: 'relations-quick-add-general-master',
+    RELATIONS_SLAVE_TAB_COMPONENT_BUS_NAME: 'relations-quick-add-general-slave'
+
+};

--- a/src/shared/services/busNames.js
+++ b/src/shared/services/busNames.js
@@ -1,4 +1,4 @@
-export default {
+export const busNames = {
 
     TOP_LEFT_ADD_BUTTON_COMPONENT_BUS_NAME: 'board plus quick add general',
 
@@ -13,3 +13,8 @@ export default {
     RELATIONS_SLAVE_TAB_COMPONENT_BUS_NAME: 'relations-quick-add-general-slave'
 
 };
+
+export const isGlobalOrRelationsBus = (busName) =>
+    busName === busNames.TOP_LEFT_ADD_BUTTON_COMPONENT_BUS_NAME ||
+    busName === busNames.RELATIONS_MASTER_TAB_COMPONENT_BUS_NAME ||
+    busName === busNames.RELATIONS_SLAVE_TAB_COMPONENT_BUS_NAME;

--- a/src/shared/services/store.js
+++ b/src/shared/services/store.js
@@ -104,7 +104,7 @@ var processOpts = function(options = {}, defaultOpts = {take: 1000}) {
     }
 
     return opts;
-}
+};
 
 module.exports = {
 

--- a/src/shared/services/store2.js
+++ b/src/shared/services/store2.js
@@ -29,8 +29,7 @@ var load = function(resource, params) {
 
         return request('get', url, params)
             .then(function(res) {
-                var items = res.items;
-                return items;
+                return res.items;
             });
     };
 
@@ -60,7 +59,7 @@ var processResult = function(result) {
 var processOpts = function(options) {
 
     return options;
-}
+};
 
 module.exports = {
 

--- a/src/shared/utils/__tests__/decodeSliceValue.js
+++ b/src/shared/utils/__tests__/decodeSliceValue.js
@@ -4,8 +4,11 @@ describe('decodeSliceValue', () => {
 
     it('decodes', () => {
 
-        expect(decodeSliceValue('b64_NDg4_')).to.be.equal('488');
+        expect(decodeSliceValue('')).to.be.equal('');
+        expect(decodeSliceValue(null)).to.be.equal(null);
         expect(decodeSliceValue('foo')).to.be.equal('foo');
+
+        expect(decodeSliceValue('b64_NDg4_')).to.be.equal('488');
         expect(decodeSliceValue('b64_///')).to.be.equal('');
 
     });

--- a/src/shared/utils/decodeSliceValue.js
+++ b/src/shared/utils/decodeSliceValue.js
@@ -35,7 +35,7 @@ const decodeBase64 = function(s) {
 
 export default (value) => {
 
-    if (value.indexOf('b64_') !== 0) return value;
+    if (!value || value.indexOf('b64_') !== 0) return value;
 
     var encoded = value;
     encoded = encoded.replace(/_0/g, '+');


### PR DESCRIPTION
* Backward-compatible fix for new & old quick add API support.
* Fix mashup integration with relations quick adds (was not applied to a outbound qa).
* Fix not first general quick add opening with mashup integration.
* Fix axis quick add with mashups integration (+ special case for project axis).
* Fix showing not required fields after item add in quick add.
* Fix showing custom fields *before* Relation type in Relations quick adds.
* Fix support for projects - allow to apply mashup for projects.
* Tests for decodeSliceValue.



