### PR TITLE
Support team workflow - use parent entity states

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,9 @@ After the mashup has been installed, it will need to be configured. Click the Cu
 * Specify an _Entity State_, when moving to this state in the workflow the custom field will be required, as a ```‘name:’``` in an ```‘entityStates:’``` section.
 * Specify a _Name_ of a Custom Field, which will be required, as a ```‘requiredCustomFields:’``` in an ```‘entityStates:’``` section. 
 
-_Note: In the case where multiple custom fields are required, provide a comma separated list of custom fields._
+_Note: In the case where multiple custom fields are required, provide a comma separated list of custom fields.
+Also, when you use [custom team workflows](https://www.targetprocess.com/guide/settings/states-workflows/team-workflow/), 
+specify the Entity State for related Project Workflow instead of a Team one._
 
 
 ## To configure Custom Field Constraints

--- a/src/screens/Form/components/FormContainer.js
+++ b/src/screens/Form/components/FormContainer.js
@@ -4,9 +4,9 @@ import {when} from 'jquery';
 
 import Overlay from 'components/Overlay';
 import store from 'services/store';
-import store2 from 'services/store2';
 
 import {getCustomFieldsForAxes} from 'services/axes';
+import {getCustomFields} from 'services/loaders';
 
 import {isUser, isGeneral, isAssignable, isRequester, equalIgnoreCase} from 'utils';
 
@@ -15,12 +15,6 @@ import FormComponent from './Form';
 import CustomField from 'services/CustomField';
 import * as CustomFieldValue from 'services/CustomFieldValue';
 import Form from 'services/Form';
-
-const getCustomFieldsByEntity = (processId, entity) => store2.get('CustomField', {
-    take: 1000,
-    where: `process.id == ${processId || 'null'} and entityType.name == "${entity.entityType.name}"`,
-    select: 'new(required, name, id, config, fieldType, value, entityType, process)'
-});
 
 const loadFullEntity = (entity) => {
 
@@ -177,8 +171,9 @@ export default class FormContainer extends React.Component {
         .then((fullEntity) => {
 
             const process = getProcess(fullEntity);
+            const entityStates = getCustomFieldsForAxes.preloadEntityStates([process]);
 
-            return when(getCustomFieldsByEntity(process.id, fullEntity), fullEntity, process);
+            return when(getCustomFields(process.id, fullEntity.entityType), fullEntity, process, entityStates);
 
         })
         .then((serverCustomFields, fullEntity, process) => {

--- a/src/shared/services/__tests__/axes.js
+++ b/src/shared/services/__tests__/axes.js
@@ -116,6 +116,70 @@ describe('axes', () => {
 
             });
 
+            it('returns custom fields of parent entity state for entity state id', () => {
+
+                const axes = [{
+                    type: 'entitystate',
+                    targetValue: {
+                        id: 42
+                    }
+                }];
+
+                $ajax.onCall(0).returns(when({
+                    Items: [{
+                        id: 42,
+                        name: 'Opened (Open)',
+                        entityType: {
+                            name: 'Bug'
+                        },
+                        parentEntityState: {
+                            id: 10,
+                            name: 'Open',
+                            entityType: {
+                                name: 'Bug'
+                            },
+                            workflow: {
+                                process: {
+                                    id: 777
+                                }
+                            }
+                        },
+                        workflow: {
+                            process: {
+                                id: 777
+                            }
+                        }
+                    }, {
+                        id: 43,
+                        name: 'Ready',
+                        entityType: {
+                            name: 'Bug'
+                        },
+                        workflow: {
+                            process: {
+                                id: 777
+                            }
+                        }
+                    }]
+                }));
+
+                $ajax.onCall(1).returns(when({
+                    items: [{
+                        name: 'Cf1',
+                        id: 1
+                    }]
+                }));
+
+                return getCustomFieldsForAxes.preloadEntityStates(processes)
+                    .then(() => getCustomFieldsForAxes(config, axes, processes, entity))
+                    .then((res) => expect(res)
+                        .to.be.eql([{
+                            name: 'Cf1',
+                            id: 1
+                        }]));
+
+            });
+
             it('returns custom fields for entity state name', () => {
 
                 const axes = [{
@@ -128,6 +192,65 @@ describe('axes', () => {
                         name: 'Open',
                         entityType: {
                             name: 'Bug'
+                        },
+                        workflow: {
+                            process: {
+                                id: 777
+                            }
+                        }
+                    }, {
+                        name: 'Open',
+                        entityType: {
+                            name: 'UserStory'
+                        },
+                        workflow: {
+                            process: {
+                                id: 777
+                            }
+                        }
+                    }]
+                }));
+
+                $ajax.onCall(1).returns(when({
+                    items: [{
+                        name: 'Cf1',
+                        id: 1
+                    }]
+                }));
+
+                return getCustomFieldsForAxes.preloadEntityStates(processes)
+                    .then(() => getCustomFieldsForAxes(config, axes, processes, entity))
+                    .then((res) => expect(res)
+                        .to.be.eql([{
+                            name: 'Cf1',
+                            id: 1
+                        }]));
+
+            });
+
+            it('returns custom fields of parent entity state for entity state name', () => {
+
+                const axes = [{
+                    type: 'entitystate',
+                    targetValue: 'open'
+                }];
+
+                $ajax.onCall(0).returns(when({
+                    Items: [{
+                        name: 'Opened (Open)',
+                        entityType: {
+                            name: 'Bug'
+                        },
+                        parentEntityState: {
+                            name: 'Open',
+                            entityType: {
+                                name: 'Bug'
+                            },
+                            workflow: {
+                                process: {
+                                    id: 777
+                                }
+                            }
                         },
                         workflow: {
                             process: {
@@ -203,6 +326,57 @@ describe('axes', () => {
 
             });
 
+            it('returns custom fields of parent entity name for entity state shortcut', () => {
+
+                const axes = [{
+                    type: 'entitystate',
+                    targetValue: '_final'
+                }];
+
+                $ajax.onCall(0).returns(when({
+                    Items: [{
+                        name: 'Ready to do (Open)',
+                        isFinal: false,
+                        parentEntityState: {
+                            name: 'Open',
+                            isFinal: true,
+                            entityType: {
+                                name: 'Bug'
+                            },
+                            workflow: {
+                                process: {
+                                    id: 777
+                                }
+                            }
+                        },
+                        entityType: {
+                            name: 'Bug'
+                        },
+                        workflow: {
+                            process: {
+                                id: 777
+                            }
+                        }
+                    }]
+                }));
+
+                $ajax.onCall(1).returns(when({
+                    items: [{
+                        name: 'Cf1',
+                        id: 1
+                    }]
+                }));
+
+                return getCustomFieldsForAxes.preloadEntityStates(processes)
+                    .then(() => getCustomFieldsForAxes(config, axes, processes, entity))
+                    .then((res) => expect(res)
+                        .to.be.eql([{
+                            name: 'Cf1',
+                            id: 1
+                        }]));
+
+            });
+
             it('returns none if entity state is not found', () => {
 
                 const axes = [{
@@ -215,6 +389,58 @@ describe('axes', () => {
                         name: 'Open',
                         entityType: {
                             name: 'Bug'
+                        },
+                        workflow: {
+                            process: {
+                                id: 777
+                            }
+                        }
+                    }]
+                }));
+
+                $ajax.onCall(1).returns(when({
+                    items: [{
+                        name: 'Cf1',
+                        id: 1
+                    }]
+                }));
+
+                return getCustomFieldsForAxes.preloadEntityStates(processes)
+                    .then(() => getCustomFieldsForAxes(config, axes, processes, entity))
+                    .then((res) => {
+
+                        expect(res).to.be.eql([]);
+                        expect($ajax).to.be.calledOnce;
+
+                    });
+
+            });
+
+            it('returns none if entity state is found but parent entity state is not', () => {
+
+                const axes = [{
+                    type: 'entitystate',
+                    targetValue: '_final'
+                }];
+
+                $ajax.onCall(0).returns(when({
+                    Items: [{
+                        name: 'Rejected (In Progress)',
+                        entityType: {
+                            name: 'Bug'
+                        },
+                        isFinal: true,
+                        parentEnityState: {
+                            name: 'In Progress',
+                            entityType: {
+                                name: 'Bug'
+                            },
+                            isFinal: false,
+                            workflow: {
+                                process: {
+                                    id: 777
+                                }
+                            }
                         },
                         workflow: {
                             process: {

--- a/src/shared/services/__tests__/axes.js
+++ b/src/shared/services/__tests__/axes.js
@@ -101,7 +101,8 @@ describe('axes', () => {
 
                 $ajax.onCall(1).returns(when({
                     items: [{
-                        name: 'Cf1'
+                        name: 'Cf1',
+                        id: 1
                     }]
                 }));
 
@@ -109,7 +110,8 @@ describe('axes', () => {
                     .then(() => getCustomFieldsForAxes(config, axes, processes, entity))
                     .then((res) => expect(res)
                         .to.be.eql([{
-                            name: 'Cf1'
+                            name: 'Cf1',
+                            id: 1
                         }]));
 
             });
@@ -147,7 +149,8 @@ describe('axes', () => {
 
                 $ajax.onCall(1).returns(when({
                     items: [{
-                        name: 'Cf1'
+                        name: 'Cf1',
+                        id: 1
                     }]
                 }));
 
@@ -155,7 +158,8 @@ describe('axes', () => {
                     .then(() => getCustomFieldsForAxes(config, axes, processes, entity))
                     .then((res) => expect(res)
                         .to.be.eql([{
-                            name: 'Cf1'
+                            name: 'Cf1',
+                            id: 1
                         }]));
 
             });
@@ -184,7 +188,8 @@ describe('axes', () => {
 
                 $ajax.onCall(1).returns(when({
                     items: [{
-                        name: 'Cf1'
+                        name: 'Cf1',
+                        id: 1
                     }]
                 }));
 
@@ -192,7 +197,8 @@ describe('axes', () => {
                     .then(() => getCustomFieldsForAxes(config, axes, processes, entity))
                     .then((res) => expect(res)
                         .to.be.eql([{
-                            name: 'Cf1'
+                            name: 'Cf1',
+                            id: 1
                         }]));
 
             });
@@ -220,7 +226,8 @@ describe('axes', () => {
 
                 $ajax.onCall(1).returns(when({
                     items: [{
-                        name: 'Cf1'
+                        name: 'Cf1',
+                        id: 1
                     }]
                 }));
 
@@ -371,13 +378,17 @@ describe('axes', () => {
 
                 $ajax.onCall(1).returns(when({
                     items: [{
-                        name: 'Cf1'
+                        name: 'Cf1',
+                        id: 1
                     }, {
-                        name: 'Cf2'
+                        name: 'Cf2',
+                        id: 2
                     }, {
-                        name: 'Cf3'
+                        name: 'Cf3',
+                        id: 3
                     }, {
-                        name: 'Cf0'
+                        name: 'Cf0',
+                        id: 0
                     }]
                 }));
 
@@ -385,11 +396,14 @@ describe('axes', () => {
                     .then(() => getCustomFieldsForAxes(config, axes, processes, entity))
                     .then((res) => expect(res)
                         .to.be.eql([{
-                            name: 'Cf0'
+                            name: 'Cf0',
+                            id: 0
                         }, {
-                            name: 'Cf2'
+                            name: 'Cf2',
+                            id: 2
                         }, {
-                            name: 'Cf3'
+                            name: 'Cf3',
+                            id: 3
                         }]));
 
             });

--- a/src/shared/services/__tests__/axes.js
+++ b/src/shared/services/__tests__/axes.js
@@ -79,12 +79,22 @@ describe('axes', () => {
                         name: 'Open',
                         entityType: {
                             name: 'Bug'
+                        },
+                        workflow: {
+                            process: {
+                                id: 777
+                            }
                         }
                     }, {
                         id: 43,
                         name: 'Open',
                         entityType: {
                             name: 'Bug'
+                        },
+                        workflow: {
+                            process: {
+                                id: 777
+                            }
                         }
                     }]
                 }));
@@ -95,10 +105,12 @@ describe('axes', () => {
                     }]
                 }));
 
-                return getCustomFieldsForAxes(config, axes, processes, entity).then((res) => expect(res)
-                    .to.be.eql([{
-                        name: 'Cf1'
-                    }]));
+                return getCustomFieldsForAxes.preloadEntityStates(processes)
+                    .then(() => getCustomFieldsForAxes(config, axes, processes, entity))
+                    .then((res) => expect(res)
+                        .to.be.eql([{
+                            name: 'Cf1'
+                        }]));
 
             });
 
@@ -114,11 +126,21 @@ describe('axes', () => {
                         name: 'Open',
                         entityType: {
                             name: 'Bug'
+                        },
+                        workflow: {
+                            process: {
+                                id: 777
+                            }
                         }
                     }, {
                         name: 'Open',
                         entityType: {
                             name: 'UserStory'
+                        },
+                        workflow: {
+                            process: {
+                                id: 777
+                            }
                         }
                     }]
                 }));
@@ -129,10 +151,12 @@ describe('axes', () => {
                     }]
                 }));
 
-                return getCustomFieldsForAxes(config, axes, processes, entity).then((res) => expect(res)
-                    .to.be.eql([{
-                        name: 'Cf1'
-                    }]));
+                return getCustomFieldsForAxes.preloadEntityStates(processes)
+                    .then(() => getCustomFieldsForAxes(config, axes, processes, entity))
+                    .then((res) => expect(res)
+                        .to.be.eql([{
+                            name: 'Cf1'
+                        }]));
 
             });
 
@@ -149,6 +173,11 @@ describe('axes', () => {
                         isFinal: true,
                         entityType: {
                             name: 'Bug'
+                        },
+                        workflow: {
+                            process: {
+                                id: 777
+                            }
                         }
                     }]
                 }));
@@ -159,10 +188,12 @@ describe('axes', () => {
                     }]
                 }));
 
-                return getCustomFieldsForAxes(config, axes, processes, entity).then((res) => expect(res)
-                    .to.be.eql([{
-                        name: 'Cf1'
-                    }]));
+                return getCustomFieldsForAxes.preloadEntityStates(processes)
+                    .then(() => getCustomFieldsForAxes(config, axes, processes, entity))
+                    .then((res) => expect(res)
+                        .to.be.eql([{
+                            name: 'Cf1'
+                        }]));
 
             });
 
@@ -178,6 +209,11 @@ describe('axes', () => {
                         name: 'Open',
                         entityType: {
                             name: 'Bug'
+                        },
+                        workflow: {
+                            process: {
+                                id: 777
+                            }
                         }
                     }]
                 }));
@@ -188,12 +224,14 @@ describe('axes', () => {
                     }]
                 }));
 
-                return getCustomFieldsForAxes(config, axes, processes, entity).then((res) => {
+                return getCustomFieldsForAxes.preloadEntityStates(processes)
+                    .then(() => getCustomFieldsForAxes(config, axes, processes, entity))
+                    .then((res) => {
 
-                    expect(res).to.be.eql([]);
-                    expect($ajax).to.be.calledOnce;
+                        expect(res).to.be.eql([]);
+                        expect($ajax).to.be.calledOnce;
 
-                });
+                    });
 
             });
 
@@ -322,6 +360,11 @@ describe('axes', () => {
                         name: 'Open',
                         entityType: {
                             name: 'Bug'
+                        },
+                        workflow: {
+                            process: {
+                                id: 777
+                            }
                         }
                     }]
                 }));
@@ -338,14 +381,16 @@ describe('axes', () => {
                     }]
                 }));
 
-                return getCustomFieldsForAxes(config, axes, processes, entity).then((res) => expect(res)
-                    .to.be.eql([{
-                        name: 'Cf0'
-                    }, {
-                        name: 'Cf2'
-                    }, {
-                        name: 'Cf3'
-                    }]));
+                return getCustomFieldsForAxes.preloadEntityStates(processes)
+                    .then(() => getCustomFieldsForAxes(config, axes, processes, entity))
+                    .then((res) => expect(res)
+                        .to.be.eql([{
+                            name: 'Cf0'
+                        }, {
+                            name: 'Cf2'
+                        }, {
+                            name: 'Cf3'
+                        }]));
 
             });
 

--- a/src/shared/services/interrupt/quickAdd.js
+++ b/src/shared/services/interrupt/quickAdd.js
@@ -6,15 +6,14 @@ import {
 
 import {addBusListener} from 'targetprocess-mashup-helper/lib/events';
 
+import decodeSliceValue from 'utils/decodeSliceValue';
+import {inValues, equalIgnoreCase, isAssignable, SLICE_CUSTOMFIELD_PREFIX} from 'utils';
+
 import {
     isSameEntityType, getAcid, getEntityTypes, getSliceDefinition, shouldIgnoreAxes
 } from 'services/apiCompatibility';
-import decodeSliceValue from 'utils/decodeSliceValue';
-import {inValues, equalIgnoreCase, isAssignable, SLICE_CUSTOMFIELD_PREFIX} from 'utils';
 import {busNames} from 'services/busNames';
-
 import store from 'services/store';
-
 import {getCustomFieldsForAxes} from 'services/axes';
 
 const onRender = (configurator, componentBusName, cb) => {
@@ -246,6 +245,7 @@ const findCustomFieldElByName = ($el, name, processId) =>
     processId
     ? $el.find(`.cf-process_${processId} > [data-iscf=true][data-fieldname="${name}"]`)
     : $el.find(`[data-iscf=true][data-fieldname="${name}"]`);
+
 const hideCustomFieldEl = ($cfEl) => {
 
     const $cfParent = $cfEl.parent();
@@ -355,9 +355,9 @@ const getActiveProcess = ($el, axes) => {
 
     if (processId) return loadProcessDirect(processId);
 
-    const promise = getProcessByProcessAxis(axes);
+    const process = getProcessByProcessAxis(axes);
 
-    if (promise) return promise;
+    if (process) return process;
 
     const projectId = getProjectValue($el);
 
@@ -437,6 +437,8 @@ const applyToComponent = (config, {busName}) =>
         const entityTypes = getEntityTypes(initData, bindData);
 
         when(getProcesses(configurator, busName, initData))
+        .then((processes) =>
+            when(processes, getCustomFieldsForAxes.preloadEntityStates(processes)))
         .then((processes) =>
             whenList(entityTypes.map((entityType) => {
 

--- a/src/shared/services/interrupt/quickAdd.js
+++ b/src/shared/services/interrupt/quickAdd.js
@@ -422,7 +422,12 @@ const listenQuickAddComponentBusForEntityType = (configurator, busName, config, 
             when(getActiveProcess($el, axes))
                 .then((process) => {
 
-                    actualValues[process.id] = activeValues;
+                    if (process) {
+
+                        actualValues[process.id] = activeValues;
+
+                    }
+
                     handler(process, activeValues);
 
                 });

--- a/src/shared/services/interrupt/quickAdd.js
+++ b/src/shared/services/interrupt/quickAdd.js
@@ -125,7 +125,10 @@ const getTargetValue = ({config}, axisName) =>
 
 const removeUnknownAxes = (axes) => reject(axes, (axis) => axis.targetValue === void 0);
 
-const useDefaultAxis = ({entityType}) =>
+const isTeamEntityStateAxis = (axes) =>
+    some(axes, (a) => a.type === 'teamentitystate');
+
+const useNewEntityStateAxis = ({entityType}) =>
     isAssignable({entityType}) ||
     equalIgnoreCase(entityType.name, 'impediment') ||
     equalIgnoreCase(entityType.name, 'project');
@@ -147,6 +150,16 @@ const getCustomAxes = (initData) => {
 
             return res.concat({
                 type: 'entitystate',
+                targetValue: getTargetValue(initData, axisName)
+            });
+
+        }
+
+        // to check team entity state is the same as in config.
+        if (inValues(axisTypes, 'teamentitystate')) {
+
+            return res.concat({
+                type: 'teamentitystate',
                 targetValue: getTargetValue(initData, axisName)
             });
 
@@ -192,16 +205,16 @@ const getCustomAxes = (initData) => {
 
 const getAxes = (busName, initData, entityType) => {
 
-    const defaultAxes = [{
+    const newEntityStateAxes = [{
         type: 'entitystate',
         targetValue: '_Initial'
     }];
 
     const axes = shouldIgnoreAxes(busName) ? [] : removeUnknownAxes(getCustomAxes(initData));
 
-    if (useDefaultAxis({entityType})) {
+    if (useNewEntityStateAxis({entityType}) && !isTeamEntityStateAxis(axes)) {
 
-        return unique(axes.concat(defaultAxes), (v) => v.type);
+        return unique(axes.concat(newEntityStateAxes), (v) => v.type);
 
     }
     else return axes;

--- a/src/shared/services/interrupt/quickAdd.js
+++ b/src/shared/services/interrupt/quickAdd.js
@@ -70,19 +70,29 @@ const getCustomFieldTemplate = (customField, types) => {
 
 const events = ['afterInit:last', 'before_dataBind'];
 
-const injectCustomFieldTemplateItem = (items, injectedItem) => {
+const findNewCustomFieldIndex = (items) => {
 
-    const updatedItems = reject(items, (item) =>
+    const relationsItemIndex = findLastIndex(items, (item) =>
+        item.id === 'SlaveRelations:RelationType' || item.id === 'MasterRelations:RelationType');
+
+    return relationsItemIndex === -1 ? items.length : relationsItemIndex;
+
+};
+
+const removeAlreadyInjectedCustomField = (items, injectedItem) =>
+    reject(items, (item) =>
         item.type === 'CustomField' &&
         item.caption === injectedItem.caption &&
         item.processId === injectedItem.processId);
-    const relationsItemIndex = findLastIndex(updatedItems, (item) =>
-        item.id === 'SlaveRelations:RelationType' || item.id === 'MasterRelations:RelationType');
-    const injectedItemIndex = relationsItemIndex === -1 ? updatedItems.length : relationsItemIndex;
 
-    updatedItems.splice(injectedItemIndex, 0, injectedItem);
+const injectCustomFieldTemplateItem = (items, injectedItem) => {
 
-    return updatedItems;
+    const newItems = removeAlreadyInjectedCustomField(items, injectedItem);
+    const injectedIndex = findNewCustomFieldIndex(newItems);
+
+    newItems.splice(injectedIndex, 0, injectedItem);
+
+    return newItems;
 
 };
 
@@ -164,7 +174,7 @@ const getCustomAxes = (initData) => {
 
         }
 
-        // to get process if one of axis is project.
+        // to get process if one of axes is project.
         if (inValues(axisTypes, 'project')) {
 
             return res.concat({
@@ -174,7 +184,7 @@ const getCustomAxes = (initData) => {
 
         }
 
-        // to get process if one of axis is process.
+        // to get process if one of axes is process.
         if (inValues(axisTypes, 'process')) {
 
             return res.concat({

--- a/src/shared/services/interrupt/quickAdd.js
+++ b/src/shared/services/interrupt/quickAdd.js
@@ -389,7 +389,7 @@ const listenQuickAddComponentBusForEntityType = (configurator, busName, config, 
 
     let allCustomFields = [];
     let activeCustomFields = [];
-    let actualValues = {};
+    const actualValues = {};
 
     onRender(configurator, busName, ($elCommon, componentBus) => {
 
@@ -417,13 +417,19 @@ const listenQuickAddComponentBusForEntityType = (configurator, busName, config, 
 
         onCustomFieldsChange($el, allCustomFields, () => {
 
-            actualValues = collectValues($el, activeCustomFields);
+            const activeValues = collectValues($el, activeCustomFields);
+
             when(getActiveProcess($el, axes))
-                .then((process) => handler(process, actualValues));
+                .then((process) => {
+
+                    actualValues[process.id] = activeValues;
+                    handler(process, activeValues);
+
+                });
 
         });
 
-        onProcessChange($el, axes, (process) => handler(process, actualValues));
+        onProcessChange($el, axes, (process) => handler(process, actualValues[process.id]));
 
     });
 

--- a/src/shared/services/loaders.js
+++ b/src/shared/services/loaders.js
@@ -1,0 +1,154 @@
+import {filter, memoize, pluck} from 'underscore';
+
+import {isGeneral} from 'utils';
+
+import store from 'services/store';
+import store2 from 'services/store2';
+
+export const getCustomFields = memoize((processId, entityType) =>
+    store2.get('CustomField', {
+        take: 1000,
+        where: `process.
+        id == ${processId || 'null'} and entityType.name == "${entityType.name}"`,
+        select: 'new(required, name, id, config, fieldType, value, entityType, process)'
+    }), (processId, entityType) => processId + entityType.name);
+
+export const loadCustomFields = memoize((processId, entityType) => {
+
+    let fields;
+
+    if (isGeneral({entityType})) {
+
+        fields = getCustomFields(processId, entityType);
+
+    } else {
+
+        fields = getCustomFields(null, entityType);
+
+    }
+
+    return fields.then((items) => items.filter((v) => v.config ? !v.config.calculationModel : true));
+
+}, (processId, entityType) => processId + entityType.name);
+
+export const loadTeamsData = memoize((entity) =>
+    store.get(entity.entityType.name, entity.id, {
+        include: [{
+            project: {
+                process: ['id'],
+                teamProjects: ['id']
+            },
+            assignedTeams: [
+                'id',
+                {
+                    team: ['id']
+                }
+            ]
+        }]
+    }), (entity) => entity.entityType.name + entity.id);
+
+export const loadTeamProjects = memoize((ids) => {
+
+    if (!ids.length) return [];
+
+    return store.get('TeamProjects', {
+        include: [{
+            team: ['id']
+        }, {
+            project: ['id']
+        }, {
+            workflows: ['id', 'name', {
+                entityType: ['name']
+            }, {
+                parentWorkflow: ['id']
+            }]
+        }],
+        where: `id in (${ids.join(',')})`
+    });
+
+});
+
+const getEntityStatesIncludes = () => {
+
+    const entityStateIncludes = [{
+        workflow: [
+            'id', {
+                process: ['id']
+            }
+        ]
+    }, {
+        process: ['id']
+    }, {
+        entityType: ['name']
+    },
+        'name',
+        'isInitial',
+        'isFinal',
+        'isPlanned', {
+            subEntityStates: [
+                'id',
+                'name', {
+                    workflow: ['id']
+                },
+                'isInitial',
+                'isFinal',
+                'isPlanned'
+            ]
+        }];
+
+    return entityStateIncludes.concat({
+        parentEntityState: entityStateIncludes
+    });
+
+};
+
+export const preloadEntityStates = (processes) => {
+
+    const processIds = pluck(processes, 'id');
+
+    return store.get('EntityStates', {
+        include: getEntityStatesIncludes(),
+        where: `Workflow.Process.id in (${processIds.join()})`
+    }).then((entityStates) => {
+
+        preloadEntityStates.cache = [];
+
+        processIds.forEach((id) => {
+
+            const states = filter(entityStates, (state) => state.workflow.process.id === id);
+
+            preloadEntityStates.cache[id] = states;
+
+        });
+
+        return preloadEntityStates.cache;
+
+    });
+
+};
+
+preloadEntityStates.getStates = (processId) => {
+
+    const entityStates = preloadEntityStates.cache[processId];
+
+    if (entityStates === void 0) {
+
+        throw new Error(`Need to preload Entity States for process.id ${processId}.`);
+
+    }
+
+    return entityStates;
+
+};
+
+export const loadEntityStates = (processId) => preloadEntityStates.getStates(processId);
+
+export const resetLoadersCache = () => {
+
+    preloadEntityStates.cache = [];
+    getCustomFields.cache = [];
+    loadCustomFields.cache = [];
+    loadTeamsData.cache = [];
+    loadTeamProjects.cache = [];
+
+};


### PR DESCRIPTION
* Since mashup is configured for parent workflow entity state, we should use
parent workflow entity state for team workflow state when apply mashup constraints.
* Query entity states by workflow process, since custom workflow entity states 
have no Process field set & Process field is deprecated. See  https://plan.tpondemand.com/api/v1/EntityStates/meta for details.
* Support for team workflow in quick add - custom handling of team entity states.
* Performance fixes - bulk Entity State queries + Custom Fields cache.
* Fixed a couple of bugs with support of custom fields with same names in different processes.
* Tests for checks of parent EntityStates constraints application. 
