### PR TITLE
Fix `TypeError: e.toLowerCase is not a function`

### DIFF
--- a/src/shared/utils/index.js
+++ b/src/shared/utils/index.js
@@ -10,7 +10,7 @@ export const equalByShortcut = (shortcut, entityState) => {
         _initial: entityState.isInitial,
         _final: entityState.isFinal,
         _planned: entityState.isPlanned
-    })[lc(shortcut)] || false;
+    })[lc(String(shortcut))] || false;
 
 };
 


### PR DESCRIPTION
```
TypeError: e.toLowerCase is not a function
    at t.lc (https://artromickspg.tpondemand.com/api/assets/mashupsBundle:4:14484)
    at t.equalByShortcut (https://artromickspg.tpondemand.com/api/assets/mashupsBundle:4:14671)
    at C (https://artromickspg.tpondemand.com/api/assets/mashupsBundle:4:20334)
    at A (https://css.cdntpondemand.com/3_8_10_26720/tau/bundle/initial.js?475842d8456062244a6e:15:15551)
    at n (https://css.cdntpondemand.com/3_8_10_26720/tau/bundle/initial.js?475842d8456062244a6e:15:16072)
    at E (https://artromickspg.tpondemand.com/api/assets/mashupsBundle:4:20394)
    at https://artromickspg.tpondemand.com/api/assets/mashupsBundle:4:21810
    at Function.findIndex (https://css.cdntpondemand.com/3_8_10_26720/tau/bundle/initial.js?475842d8456062244a6e:15:8711)
    at x.find.x.detect (https://css.cdntpondemand.com/3_8_10_26720/tau/bundle/initial.js?475842d8456062244a6e:15:10995)
    at Array.<anonymous> (https://artromickspg.tpondemand.com/api/assets/mashupsBundle:4:21756)
```