### PR TITLE
US#151110 Do not require to enter values of system custom fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "CustomFieldConstraints",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "This mashup allows a custom field to be required when an entity is moved to a specific state or a specific value is selected in another custom field.",
   "author": "Aliaksei Shytkin <shitkin@targetprocess.com>",
   "scripts": {

--- a/src/shared/services/__tests__/axes.js
+++ b/src/shared/services/__tests__/axes.js
@@ -550,6 +550,34 @@ describe('axes', () => {
 
             });
 
+            it('skips system custom fields', () => {
+
+                const axes = [{
+                    type: 'customfield',
+                    customFieldName: 'sys-field',
+                    targetValue: '42'
+                }];
+
+                $ajax.onCall(0).returns(when({
+                    items: [{
+                        name: 'cf1',
+                        entityType: {
+                            name: 'Bug'
+                        }
+                    }, {
+                        name: 'sys-field',
+                        entityType: {
+                            name: 'Bug'
+                        },
+                        isSystem: true
+                    }]
+                }));
+
+                return getCustomFieldsForAxes(config, axes, processes, entity).then((res) => expect(res)
+                    .to.be.eql([]));
+
+            });
+
         });
 
         describe('merges axes custom fields', () => {

--- a/src/shared/services/loaders.js
+++ b/src/shared/services/loaders.js
@@ -7,7 +7,7 @@ import store2 from 'services/store2';
 export const getCustomFields = memoize((processId, entityType) =>
     store2.get('CustomField', {
         where: `process.id == ${processId || 'null'} and entityType.name == "${entityType.name}"`,
-        select: 'new(required, name, id, config, fieldType, value, numericPriority, entityType, process)'
+        select: 'new(required, name, id, config, fieldType, value, numericPriority, entityType, process, isSystem)'
     }), (processId, entityType) => processId + entityType.name);
 
 export const loadCustomFields = memoize((processId, entityType) => {
@@ -24,7 +24,9 @@ export const loadCustomFields = memoize((processId, entityType) => {
 
     }
 
-    return fields.then((items) => items.filter((v) => v.config ? !v.config.calculationModel : true));
+    const isCalculated = (cf) => cf.config && cf.config.calculationModel;
+
+    return fields.then((items) => items.filter((cf) => !cf.isSystem && !isCalculated(cf)));
 
 }, (processId, entityType) => processId + entityType.name);
 


### PR DESCRIPTION
~~Still to do: handle somehow the situation when `isSystem` field is not available (e.g. when new version of mash-up is installed on the "old" version of TP)~~ *Done*

If `systemCustomFields` feature is turned on, then the mash-up will filter out system custom fields, so that they won't be presented to the end-users.